### PR TITLE
fix: align the dropdown menu to start/left when it is the first menu

### DIFF
--- a/layouts/partials/hb/modules/header/index.html
+++ b/layouts/partials/hb/modules/header/index.html
@@ -37,8 +37,8 @@
           {{/* Menus begin. */}}
           <ul class="hb-header-menus navbar-nav flex-row flex-wrap">
             {{- $page := . }}
-            {{- range .Site.Menus.main -}}
-              {{- $menuCtx := dict "Menu" . "Page" $page }}
+            {{- range $i, $menu := .Site.Menus.main -}}
+              {{- $menuCtx := dict "Menu" $menu "Page" $page "IsFirst" (eq 0 $i) }}
               {{- partial "hb/modules/header/menu" $menuCtx }}
             {{- end -}}
           </ul>

--- a/layouts/partials/hb/modules/header/menu.html
+++ b/layouts/partials/hb/modules/header/menu.html
@@ -48,7 +48,7 @@
       </a>
     {{- end }}
     <ul
-      class="hb-header-submenus dropdown-menu dropdown-menu-end"
+      class="hb-header-submenus dropdown-menu{{ cond .IsFirst `` ` dropdown-menu-end` }}"
       aria-labelledby="{{ $menuID }}"
       data-bs-popper="none">
       {{- with $menu.Params.header }}


### PR DESCRIPTION
Fixes #62 