### PR TITLE
style: dropdown menu takes full width when there is only one menu

### DIFF
--- a/assets/hb/modules/header/scss/_header.scss
+++ b/assets/hb/modules/header/scss/_header.scss
@@ -96,6 +96,6 @@ $hb-header-logo-bg: null !default;
     }
 }
 
-.colum-span-all {
+.column-span-all {
     column-span: all;
 }

--- a/layouts/partials/hb/modules/header/menu.html
+++ b/layouts/partials/hb/modules/header/menu.html
@@ -69,12 +69,12 @@
       aria-labelledby="{{ $menuID }}"
       data-bs-popper="none">
       {{- with $menu.Params.header }}
-        <li class="colum-span-all">
+        <li class="column-span-all">
           <h6 class="dropdown-header">{{ . }}</h6>
         </li>
       {{- end }}
-      {{- range $menu.Children }}
-        {{- $submenuCtx := dict "Menu" . "Page" $page }}
+      {{- range $i, $child := $menu.Children }}
+        {{- $submenuCtx := dict "Menu" $child "Page" $page "Index" $i "Total" (len $menu.Children) }}
         {{- partial "hb/modules/header/submenu" $submenuCtx }}
       {{- end }}
     </ul>

--- a/layouts/partials/hb/modules/header/submenu.html
+++ b/layouts/partials/hb/modules/header/submenu.html
@@ -12,7 +12,8 @@
 {{- end }}
 {{- $target = default $target .Menu.Params.target }}
 {{- $rel = default $rel .Menu.Params.rel }}
-<li>
+<li
+  {{ if eq .Total 1 }}class="column-span-all"{{ end }}>
   {{- if $menu.Params.divider }}
     <hr class="dropdown-divider" />
   {{- else }}


### PR DESCRIPTION
chore: fix typos of column-span-all class

Closes #300