### PR TITLE
fix: add missing tooltip on the theme-toggle button

### DIFF
--- a/modules/theme-toggle/layouts/partials/hb/modules/header-theme-toggle/index.html
+++ b/modules/theme-toggle/layouts/partials/hb/modules/header-theme-toggle/index.html
@@ -11,6 +11,7 @@
     role="button"
     data-bs-toggle="dropdown"
     aria-expanded="false"
+    title="{{ i18n `theme_title` }}"
   >
     {{ partial "icons/icon" (dict "vendor" "bootstrap" "name" "circle-half" "className" "my-1 theme-toggle-icon") }}
     <span class="d-{{ $breakpoint }}-none ms-1">{{ i18n "theme_title" }}</span>


### PR DESCRIPTION
![image](https://github.com/hbstack/header/assets/58879166/c40a522d-de64-46ed-9282-3bdffb3ac1aa)
