### PR TITLE
style(search): fix broken style when increasing height

### DIFF
--- a/modules/search/layouts/partials/hb/modules/header-search/index.html
+++ b/modules/search/layouts/partials/hb/modules/header-search/index.html
@@ -1,20 +1,22 @@
 {{- $breakpoint := partialCached "hb/modules/header/functions/breakpoint" . }}
-<div class="search-modal-toggle hb-header-search-form position-relative d-flex ms-{{ $breakpoint }}-1">
-  <button
-    type="button"
-    class="hb-header-search-icon border-0 bg-transparent px-2"
-    aria-label="Toggle search">
-    {{ partial "icons/icon" (dict "vendor" "bootstrap" "name" "search") }}
-  </button>
-  <input
-    class="form-control rounded-5 d-none d-lg-block ms-{{ $breakpoint }}-1"
-    id="hb-header-search-input"
-    placeholder="{{ i18n `search` }}" />
-  {{- with index site.Params.search "shortcut_search" }}
-    <span class="hb-header-search-keys position-absolute d-none d-lg-block">
-      {{- range . }}
-        <kbd>{{ replace . "Control" "CTRL" | title }}</kbd>
-      {{- end }}
-    </span>
-  {{- end }}
+<div class="search-modal-toggle hb-header-search-form d-flex align-items-center ms-{{ $breakpoint }}-1">
+  <div class="hb-header-search-input-container position-relative">
+    <button
+      type="button"
+      class="hb-header-search-icon border-0 bg-transparent px-2"
+      aria-label="Toggle search">
+      {{ partial "icons/icon" (dict "vendor" "bootstrap" "name" "search") }}
+    </button>
+    <input
+      class="form-control rounded-5 d-none d-lg-block ms-{{ $breakpoint }}-1"
+      id="hb-header-search-input"
+      placeholder="{{ i18n `search` }}" />
+    {{- with index site.Params.search "shortcut_search" }}
+      <span class="hb-header-search-keys position-absolute d-none d-lg-block">
+        {{- range . }}
+          <kbd>{{ replace . "Control" "CTRL" | title }}</kbd>
+        {{- end }}
+      </span>
+    {{- end }}
+  </div>
 </div>


### PR DESCRIPTION
When the height was increased, the icon and kbds weren't aligned to the middle.

![image](https://github.com/hbstack/header/assets/17720932/f77b4fd9-fb13-40fb-ba43-c0080fca0ef8)
