### PR TITLE
make language and theme toggles stay in place when adjacent menu is activated in mobile view

### DIFF
--- a/modules/language-picker/layouts/partials/hb/modules/header-language-picker/index.html
+++ b/modules/language-picker/layouts/partials/hb/modules/header-language-picker/index.html
@@ -1,6 +1,6 @@
 {{- $breakpoint := partialCached "hb/modules/header/functions/breakpoint" . }}
 {{- if gt (len .Sites) 1 }}
-  <li class="language-picker nav-item dropdown col-6 col-{{ $breakpoint }}-auto d-flex flex-column justify-content-start">
+  <li class="language-picker nav-item dropdown col-6 col-{{ $breakpoint }}-auto d-flex flex-column justify-content-start justify-content-{{ $breakpoint }}-center">
     <a
       class="btn btn-link nav-link py-2 px-0 px-{{ $breakpoint }}-2 d-flex justify-content-start justify-content-{{ $breakpoint }}-center align-items-center"
       href="#"

--- a/modules/language-picker/layouts/partials/hb/modules/header-language-picker/index.html
+++ b/modules/language-picker/layouts/partials/hb/modules/header-language-picker/index.html
@@ -1,6 +1,6 @@
 {{- $breakpoint := partialCached "hb/modules/header/functions/breakpoint" . }}
 {{- if gt (len .Sites) 1 }}
-  <li class="language-picker nav-item dropdown col-6 col-{{ $breakpoint }}-auto d-flex flex-column justify-content-center">
+  <li class="language-picker nav-item dropdown col-6 col-{{ $breakpoint }}-auto d-flex flex-column justify-content-start">
     <a
       class="btn btn-link nav-link py-2 px-0 px-{{ $breakpoint }}-2 d-flex justify-content-start justify-content-{{ $breakpoint }}-center align-items-center"
       href="#"

--- a/modules/theme-toggle/layouts/partials/hb/modules/header-theme-toggle/index.html
+++ b/modules/theme-toggle/layouts/partials/hb/modules/header-theme-toggle/index.html
@@ -5,7 +5,7 @@
 }}
 {{- $breakpoint := partialCached "hb/modules/header/functions/breakpoint" . }}
 {{- $style := default "switch" site.Params.hb.header.theme_toggle.style }}
-<li class="theme-toggle nav-item dropdown col-6 col-{{ $breakpoint }}-auto d-flex flex-column justify-content-start">
+<li class="theme-toggle nav-item dropdown col-6 col-{{ $breakpoint }}-auto d-flex flex-column justify-content-start justify-content-{{ $breakpoint }}-center">
   <button
     class="btn btn-link btn-theme-toggle nav-link py-2 px-0 px-{{ $breakpoint }}-2 d-flex justify-content-start justify-content-{{ $breakpoint }}-center align-items-center"
     {{ if eq $style "dropdown" }}data-bs-toggle="dropdown"{{ end }}

--- a/modules/theme-toggle/layouts/partials/hb/modules/header-theme-toggle/index.html
+++ b/modules/theme-toggle/layouts/partials/hb/modules/header-theme-toggle/index.html
@@ -5,7 +5,7 @@
 }}
 {{- $breakpoint := partialCached "hb/modules/header/functions/breakpoint" . }}
 {{- $style := default "switch" site.Params.hb.header.theme_toggle.style }}
-<li class="theme-toggle nav-item dropdown col-6 col-{{ $breakpoint }}-auto d-flex flex-column justify-content-center">
+<li class="theme-toggle nav-item dropdown col-6 col-{{ $breakpoint }}-auto d-flex flex-column justify-content-start">
   <button
     class="btn btn-link btn-theme-toggle nav-link py-2 px-0 px-{{ $breakpoint }}-2 d-flex justify-content-start justify-content-{{ $breakpoint }}-center align-items-center"
     {{ if eq $style "dropdown" }}data-bs-toggle="dropdown"{{ end }}


### PR DESCRIPTION
old behaviour:

![image](https://github.com/hbstack/header/assets/159569/ba3da023-45fb-4c9b-8807-7952d588183e)

![image](https://github.com/hbstack/header/assets/159569/8b0b1e8d-ee6e-4ee3-b671-d2a72ba2bc0d)

patch:

![image](https://github.com/hbstack/header/assets/159569/d005456a-f781-44e6-b384-e876fde42393)

![image](https://github.com/hbstack/header/assets/159569/b6c92c2c-b2f7-403a-a936-f86a4d27da00)
