### PR TITLE
feat: add support for main brand

### DIFF
--- a/layouts/partials/hb/modules/header/brand.html
+++ b/layouts/partials/hb/modules/header/brand.html
@@ -1,3 +1,4 @@
+{{ partialCached "hb/modules/header/main-brand" . }}
 {{- $logo := partialCached "hb/modules/header/logo" . }}
 {{- $brand := partialCached "hb/modules/header/functions/brand" . }}
 {{- if or $logo $brand }}

--- a/layouts/partials/hb/modules/header/main-brand.html
+++ b/layouts/partials/hb/modules/header/main-brand.html
@@ -1,0 +1,25 @@
+{{- $breakpoint := partialCached "hb/modules/header/functions/breakpoint" . }}
+{{- with site.Params.hb.header.main_brand }}
+  {{- $hideTitle := default false .hide_title }}
+  <a
+    class="navbar-brand navbar-brand-main d-none d-{{ $breakpoint }}-flex align-items-center me-0"
+    title="{{ .title }}"
+    target="_blank"
+    href="{{ default `#` .url }}">
+    {{- with .logo }}
+      {{- with resources.Get . }}
+        {{- $logo := partial "hb/functions/image-resize" (dict "Image" . "Size" "x64") }}
+        <img
+          src="{{ $logo.Permalink }}"
+          alt="Logo"
+          width="{{ $logo.Width }}"
+          height="{{ $logo.Height }}"
+          class="hb-header-logo hb-header-main-brand-logo d-inline-block align-text-top{{ cond $hideTitle `` ` me-2` }}" />
+      {{- end }}
+    {{- end }}
+    {{- if not $hideTitle }}
+      {{- .title -}}
+    {{- end }}
+  </a>
+  <hr class="vr h-100 mx-2 d-none d-{{ $breakpoint }}-flex" />
+{{- end }}


### PR DESCRIPTION
```yaml
hb:
  header:
    main_brand:
      url: https://hugomods.com/
      title: HugoMods
      # hide_title: true
      logo: images/logo.png
```

- `url`: required.
- `title`: used as link title, required.
- `hide_title`: when `true` hide the title text, default to `false`.
- `logo`: logo image resource which located in `assets` folder, optional.

Fixes #489 