### PR TITLE
fix: calculate margin-bottom as early as possible to eliminate CLS issue

### DIFF
--- a/assets/hb/modules/header/js/index.ts
+++ b/assets/hb/modules/header/js/index.ts
@@ -1,6 +1,5 @@
 import "js/bootstrap/src/dropdown";
 import "js/bootstrap/src/offcanvas";
-import params from "@params";
 
 (() => {
     document.addEventListener('DOMContentLoaded', () => {
@@ -26,18 +25,6 @@ import params from "@params";
         const hide = () => {
             nav.style.opacity = '0';
             nav.style.zIndex = '0';
-        }
-
-        const topOffset = () => {
-            const v =  nav.clientHeight + 24
-            document.body.style.setProperty(`--${params.styles.prefix}top-offset`, v + 'px')
-        }
-
-        if (params.header.sticky) {
-            topOffset()
-            window.addEventListener('resize', () => {
-                topOffset()
-            })
         }
 
         let h = 0;

--- a/assets/hb/modules/header/js/init.ts
+++ b/assets/hb/modules/header/js/init.ts
@@ -1,0 +1,19 @@
+import params from "@params";
+(() => {
+  const nav = document.querySelector('.hb-header-nav') as HTMLElement
+  if (!nav) {
+    return
+  }
+
+  const topOffset = () => {
+      const v =  nav.clientHeight + 24
+      document.body.style.setProperty(`--${params.prefix}top-offset`, v + 'px')
+  }
+
+  if (params.sticky) {
+      topOffset()
+      window.addEventListener('resize', () => {
+          topOffset()
+      })
+  }
+})()

--- a/assets/hb/modules/header/scss/variables.tmpl.scss
+++ b/assets/hb/modules/header/scss/variables.tmpl.scss
@@ -2,5 +2,5 @@
 $hb-header-sticky: {{ default true $params.sticky }};
 $hb-header-menus-alignment: '{{ default "" $params.menus_alignment }}';
 $hb-header-logo-bg: {{ default "null" $params.logo_bg }};
-$hb-top-offset: if($hb-header-sticky, 7.75rem, 24px);
+$hb-top-offset: if($hb-header-sticky, 5rem, 24px);
 $hb-header-breakpoint: '{{ partialCached "hb/modules/header/functions/breakpoint" . }}';

--- a/layouts/partials/hb/modules/header/index.html
+++ b/layouts/partials/hb/modules/header/index.html
@@ -64,3 +64,4 @@
   </nav>
   {{ partial "hugopress/functions/render-hooks" (dict "Name" "hb-header-end" "Page" .) }}
 </header>
+{{ partial "hb/modules/header/init.html" . }}

--- a/layouts/partials/hb/modules/header/init.html
+++ b/layouts/partials/hb/modules/header/init.html
@@ -1,0 +1,12 @@
+{{- $opts := dict
+  "targetPath" "js/header-init.js"
+  "params" (dict
+    "prefix" (default "hb" site.Params.hb.styles.prefix)
+    "sticky" (default "hb" site.Params.hb.header.sticky))
+  "minify" hugo.IsProduction
+}}
+{{- $js := resources.Get "hb/modules/header/js/init.ts" | js.Build $opts }}
+{{- if hugo.IsProduction }}
+  {{- $js = $js | fingerprint }}
+{{- end }}
+<script src="{{ $js.RelPermalink }}"></script>


### PR DESCRIPTION
Fixes #502

As the image shown below, previously the  main body position will be changed after page was loaded.

![header-cls](https://github.com/hbstack/header/assets/17720932/4bdc1b19-3cf8-4061-9768-7c6b5605b060)
