### PR TITLE
style(socials): add gaps between social links on small screen

### DIFF
--- a/modules/socials/layouts/partials/hb/modules/header/modules/socials/index.html
+++ b/modules/socials/layouts/partials/hb/modules/header/modules/socials/index.html
@@ -4,7 +4,7 @@
   "Options" (dict
     "color" false
     "text" true
-    "textClass" (printf "d-%s-none ms-1" $breakpoint)
+    "textClass" (printf "d-%s-none ms-1 me-2" $breakpoint)
     "class" (printf "btn btn-link nav-link py-2 px-0 px-%s-2 d-flex justify-content-center align-items-center" $breakpoint)
   )
   "wrapperDiv" "li"


### PR DESCRIPTION
Before

![image](https://github.com/hbstack/header/assets/17720932/6aa60a7b-f917-4634-a4a7-ec182eac70f9)

After

![image](https://github.com/hbstack/header/assets/17720932/52dbe1ac-6a0e-4f42-ac0d-8e930837eabb)
