### PR TITLE
Improve submenu header and divider style

### DIFF
--- a/assets/hb/modules/header/scss/_header.scss
+++ b/assets/hb/modules/header/scss/_header.scss
@@ -106,6 +106,12 @@ $hb-header-logo-bg: null !default;
             &[data-columns="#{$cols}"] {
                 grid-template-columns: repeat($cols, 1fr);
 
+                > li.column-span-all,
+                > li:has(> .dropdown-divider) {
+                    grid-column: 1 / -1;
+                    width: 100%;
+                }
+
                 .hb-header-submenu {
                     .dropdown-item-desc {
                         max-width: calc(70vw / $cols);


### PR DESCRIPTION
This is how submenu looks like when `columns` is set to `2`.

<img width="418" height="468" alt="before" src="https://github.com/user-attachments/assets/974bb01f-64a8-44b2-a7fc-eaeabf750d9e" />

I personally think this looks bad.

This is how I think it should look like.

<img width="424" height="459" alt="after" src="https://github.com/user-attachments/assets/5716fea6-9ff2-43e4-9630-f35e3c2967c2" />

Submenu Header and Divider will take full width, instead of '1 column' like other submenu items.  
This even works when the number of submenu items is odd.

I've tested this myself via placing modified `_header.scss` in `assets/hb/modules/header/scss`, which will effectively override what is provided by `hbstack/header`.